### PR TITLE
Revert "Add nokogiri (for Mac) to the bundle lock for local non-docker dev"

### DIFF
--- a/food-robot-v2-back/Gemfile.lock
+++ b/food-robot-v2-back/Gemfile.lock
@@ -90,8 +90,6 @@ GEM
     minitest (5.14.4)
     msgpack (1.4.2)
     nio4r (2.5.8)
-    nokogiri (1.12.5-x86_64-darwin)
-      racc (~> 1.4)
     nokogiri (1.12.5-x86_64-linux)
       racc (~> 1.4)
     pg (1.2.3)


### PR DESCRIPTION
Reverts RosanneUssery/food-rescue-robot-v2#22

Gemfile.lock modified, not gemfile