### PR TITLE
Specify ruby:3.0.2 in Dockerfile (match project)

### DIFF
--- a/food-robot-v2-back/Dockerfile
+++ b/food-robot-v2-back/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.0
+FROM ruby:3.0.2
 RUN apt-get update -qq && apt-get install -y postgresql-client
 RUN mkdir /food_bot
 WORKDIR /food_bot


### PR DESCRIPTION
# User Story
The Dockerfile previously listed `ruby:3.0` which was pulling the last release for 3.0, which was `3.0.3`, which doesn't match the rest of the project.

# PR Checklist
- [ ] Tests written
- [x] Manual testing on local

# Additional Notes to Reviewers
Don't think so?

# How Does This PR Make You Feel?
![giphy](https://media.giphy.com/media/MdqE46HziuFJTlIwjw/giphy.gif)

